### PR TITLE
ISAICP-6549: Deploy the codebase in only one step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,13 +13,6 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 
 pipeline:
-  npm-build:
-    group: prepare
-    image: node:9.5.0
-    commands:
-      - npm install --unsafe-perm
-      - NODE_ENV=production npm run production
-
   composer-install:
     group: prepare
     image: fpfis/httpd-php-ci:${PHP_VERSION}

--- a/README.md
+++ b/README.md
@@ -28,16 +28,17 @@ In order to enable the theme in your project perform the following steps:
 
 You can build the development site by running the following steps:
 
-* Install the NPM and Composer dependencies:
+* Install the Composer dependencies:
 
 ```bash
-npm install
 composer install
 ```
 
 A post command hook (`drupal:site-setup`) is triggered automatically after `composer install`.
 It will make sure that the necessary symlinks are properly setup in the development site.
 It will also perform token substitution in development configuration files such as `behat.yml.dist`.
+
+The NPM dependencies are being automatically installed as part of `composer install`.
 
 * Install test site by running:
 

--- a/src/TaskRunner/Commands/BuildCommands.php
+++ b/src/TaskRunner/Commands/BuildCommands.php
@@ -46,6 +46,10 @@ class BuildCommands extends AbstractCommands {
       ->dir($npmDir)
       ->stopOnFail();
 
+    if (!file_exists($npmDir . '/package-lock.json')) {
+      $stack->exec('npm install');
+    }
+
     // If node_modules dir doesn't exist, run 'npm ci'.
     // See https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci
     if (!is_dir($npmDir . '/node_modules')) {


### PR DESCRIPTION
Jira issue(s):
- [ISAICP-6551](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/ISAICP-6551)

The OE Bootstrap Theme is Drupal theme, hence is designated for PHP developers. Such developers are more familiar with Composer rather than NPM.

We propose that we add `npm install` as part of `oe_bootstrap_theme:npm-run` command and we run it only if there's no `package-lock.json` present. This allows to build the codebase with just one command: `composer install`
