### PR TITLE
ISAICP-6548: Preserve link attributes in menus

### DIFF
--- a/templates/patterns/nav/pattern-nav.html.twig
+++ b/templates/patterns/nav/pattern-nav.html.twig
@@ -42,11 +42,6 @@
           'nav-link',
           item.in_active_trail ? 'active'
           ] %}
-        {% if item.url.options.attributes.class is iterable %}
-          {% set nav_link_classes = nav_link_classes|merge(item.url.options.attributes.class) %}
-        {% elseif item.url.options.attributes.class %}
-          {% set nav_link_classes = nav_link_classes|merge([item.url.options.attributes.class]) %}
-        {% endif %}
         <li class="{{- nav_item_classes|join(' ') -}}">
           {% if item.is_expanded and item.below %}
             {% set nav_link_classes = nav_link_classes|merge(['dropdown-toggle']) %}
@@ -55,8 +50,7 @@
               {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
             {% endif %}
           {% else %}
-            <a class="{{ nav_link_classes|join(' ') }}" href="{{ item.url }}"
-            {% if (item.url.options.attributes.target) %} target="{{ item.url.options.attributes.target }}" {% endif %}>{{ item.title }}</a>
+            {{ link(item.title, item.url, { 'class': nav_link_classes } ) }}
           {% endif %}
         </li>
       {% endfor %}
@@ -68,12 +62,7 @@
             'dropdown-item',
             item.in_active_trail ? 'active'
           ] %}
-          {% if item.url.options.attributes.class is iterable %}
-            {% set nav_link_classes = nav_link_classes|merge(item.url.options.attributes.class) %}
-          {% elseif item.url.options.attributes.class %}
-            {% set nav_link_classes = nav_link_classes|merge([item.url.options.attributes.class]) %}
-          {% endif %}
-          <li><a class="{{ nav_link_classes|join(' ') }}" href="{{ item.url }}">{{ item.title }}</a></li>
+          <li>{{ link(item.title, item.url, { 'class': nav_link_classes } ) }}</li>
         {% endfor %}
       </ul>
     {% endif %}


### PR DESCRIPTION
When using the theme in Joinup we are seeing test failures in the navigation menus.

After investigation it appears that the menu links are rendered by creating the `<a>` tag from scratch, preserving only the `class` and `target` attributes. All other attributes that might be present on the link are ignored. We are missing things such as the `title` attribute, aria attributes, and Drupal `data-` attributes which are needed for JavaScript behaviours.

A good solution would be to use the `link()` Twig function which preserves all attributes.