### PR TITLE
OEL-470: Upgrade BCL patterns to 0.7.0 version at package.json.

### DIFF
--- a/kits/default/package.json
+++ b/kits/default/package.json
@@ -13,7 +13,7 @@
     "production": "npm-run-all build:*"
   },
   "devDependencies": {
-    "@openeuropa/bcl-builder": "0.6.0",
+    "@openeuropa/bcl-builder": "0.7.0",
     "chokidar-cli": "^3.0.0",
     "copyfiles": "2.4.1",
     "cross-env": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "production": "npm-run-all build:*"
   },
   "devDependencies": {
-    "@openeuropa/bcl-builder": "0.6.0",
-    "@openeuropa/bcl-theme-default": "0.6.0",
+    "@openeuropa/bcl-builder": "0.7.0",
+    "@openeuropa/bcl-theme-default": "0.7.0",
     "bootstrap-ie11": "5.0.2",
     "chokidar-cli": "^3.0.0",
     "copyfiles": "2.4.1",


### PR DESCRIPTION
Jira issue(s):
- [OEL-470](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-470)
