### PR TITLE
OEL-1227: OEL-1227: Add content banner into a twig block.

### DIFF
--- a/templates/patterns/content_banner/pattern-content-banner.html.twig
+++ b/templates/patterns/content_banner/pattern-content-banner.html.twig
@@ -28,17 +28,19 @@
   {% set _badges = _badges|merge([_badge]) %}
 {% endfor %}
 
-{% include '@oe-bcl/bcl-content-banner/bcl-content-banner.html.twig' with {
-  'background': background,
-  'title': {
-    'content': title,
-  },
-  'content': _content,
-  'image': image ? {
-    'path': image.src,
-    'alt': image.alt,
-  } : {},
-  'badges': _badges,
-  'attributes': attributes,
-} only %}
+{% block attributes %}
+  {% include '@oe-bcl/bcl-content-banner/bcl-content-banner.html.twig' with {
+    'background': background,
+    'title': {
+      'content': title,
+    },
+    'content': _content,
+    'image': image ? {
+      'path': image.src,
+      'alt': image.alt,
+    } : {},
+    'badges': _badges,
+    'attributes': attributes,
+  } only %}
+{% endblock %}
 {% endspaceless %}


### PR DESCRIPTION
Jira issue(s):
- [OEL-1227](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-1227)
