### PR TITLE
OEL-1280: Revert removal of composer packages only needed for oe_bootstrap_theme_paragraphs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "drupal/config_devel": "~1.8",
         "drupal/core-composer-scaffold": "^9.2",
         "drupal/core-dev": "^9.2",
+        "drupal/description_list_field": "^1.0@alpha",
         "drupal/drupal-extension": "^4.1",
         "drupal/file_link": "^2.0.6",
         "drupal/styleguide": "^1.0@beta",
@@ -27,6 +28,9 @@
         "egulias/email-validator": "^2.1.22 || ^3.0",
         "nikic/php-parser": "^4.13",
         "openeuropa/code-review": "^2.0",
+        "openeuropa/oe_content": "^2.7.0",
+        "openeuropa/oe_media": "^1.14",
+        "openeuropa/oe_paragraphs": "^1.12",
         "openeuropa/task-runner-drupal-project-symlink": "^1.0-beta5",
         "phpspec/prophecy-phpunit": "^1 || ^2",
         "symfony/dom-crawler": "^4.4.12"


### PR DESCRIPTION
The modules have to be disabled first, and removed in a separate release.

This reverts commit d019a227a86b408d88b3ef73f39de15d63365679.

Jira issue(s):
- [D8AGE-1280](https://webgate.ec.europa.eu/CITnet/jira/browse/D8AGE-1280)
