### PR TITLE
OEL-1416: Fix 'unsafe directory' error in drone.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -88,6 +88,7 @@ pipeline:
   before-release:
     image: registry.fpfis.eu/fpfis/httpd-php:${PHP_VERSION}-ci
     commands:
+      - git config --global --add safe.directory /test/oe_bootstrap_theme
       - apt-get update
       - apt-get install zip
       - ./vendor/bin/run release:create-archive --tag=${DRONE_TAG}


### PR DESCRIPTION
This is not really part of OEL-1416, but we must fix it asap to move on with OEL-1416.

Technically this follows #230.