### PR TITLE
OEL-1983: Replace deprecated module_load_include()

### DIFF
--- a/tests/src/Kernel/AbstractKernelTestBase.php
+++ b/tests/src/Kernel/AbstractKernelTestBase.php
@@ -58,7 +58,7 @@ abstract class AbstractKernelTestBase extends KernelTestBase {
     // enhancers.
     // @see CurrentUserContext::getRuntimeContexts().
     // @see EntityConverter::convert().
-    module_load_include('install', 'user');
+    $this->container->get('module_handler')->loadInclude('user', 'install');
     user_install();
   }
 


### PR DESCRIPTION
Jira issue(s):
- [OEL-1983](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-1983): Replace deprecated module_load_include() in OEBT
