### PR TITLE
OEL-2252: Removed assistive_text from badge pattern.

### DIFF
--- a/templates/patterns/badge/pattern-badge.html.twig
+++ b/templates/patterns/badge/pattern-badge.html.twig
@@ -8,7 +8,6 @@
 {% include '@oe-bcl/badge' with {
   'label': label,
   'title': title,
-  'assistive_text': assistive_text,
   'url': url,
   'rounded_pill': rounded_pill,
   'background': background,


### PR DESCRIPTION
Jira issue(s):
- [D8AGE-???](https://webgate.ec.europa.eu/CITnet/jira/browse/D8AGE-???)
