### PR TITLE
OEL-2256: Remove col-sm-10 class from fieldsets.

### DIFF
--- a/config/install/oe_bootstrap_theme.settings.yml
+++ b/config/install/oe_bootstrap_theme.settings.yml
@@ -13,3 +13,4 @@ bootstrap_tables:
 backward_compatibility:
   card_search_image_hide_on_mobile: false
   card_search_use_grid_classes: false
+  fieldset_wrapper_col_sm_10: false

--- a/config/schema/oe_bootstrap_theme.schema.yml
+++ b/config/schema/oe_bootstrap_theme.schema.yml
@@ -22,3 +22,6 @@ oe_bootstrap_theme.settings:
         card_search_use_grid_classes:
           type: boolean
           label: 'Card to use grid classes'
+        fieldset_wrapper_col_sm_10:
+          type: boolean
+          label: 'Fieldset wrapper uses col-sm-10'

--- a/includes/form.inc
+++ b/includes/form.inc
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\oe_bootstrap_theme\BackwardCompatibility;
 
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
@@ -66,4 +67,11 @@ function oe_bootstrap_theme_preprocess_form_element(&$variables) {
  */
 function oe_bootstrap_theme_form_node_form_alter(&$form, FormStateInterface $form_state) {
   $form['#theme'] = ['node_edit_form'];
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for fieldset template.
+ */
+function oe_bootstrap_theme_preprocess_fieldset(&$variables) {
+  $variables['fieldset_wrapper_col_sm_10'] = BackwardCompatibility::getSetting('fieldset_wrapper_col_sm_10');
 }

--- a/kits/default/config/schema/default.schema.yml
+++ b/kits/default/config/schema/default.schema.yml
@@ -1,5 +1,5 @@
 # Schema for the configuration files of the OE_BOOTSTRAP_THEME_SUBTHEME_NAME theme.
 
 OE_BOOTSTRAP_THEME_SUBTHEME_MACHINE_NAME.settings:
-  type: theme_settings
+  type: oe_bootstrap_theme.settings
   label: 'OE_BOOTSTRAP_THEME_SUBTHEME_NAME settings'

--- a/templates/overrides/form/fieldset.html.twig
+++ b/templates/overrides/form/fieldset.html.twig
@@ -29,6 +29,12 @@
     errors ? 'has-error',
   ]
 %}
+{%
+  set wrapper_classes = [
+    'fieldset-wrapper',
+    fieldset_wrapper_col_sm_10 ? 'col-sm-10',
+  ]
+%}
 <fieldset{{ attributes.addClass(classes) }}>
   {% set legend_classes = [
     'col-form-label',
@@ -42,7 +48,7 @@
   <legend{{ legend.attributes.addClass(legend_classes) }}>
     <span{{ legend_span.attributes.addClass(legend_span_classes) }}>{{ legend.title }}</span>
   </legend>
-  <div class="fieldset-wrapper col-sm-10">
+  <div{{ create_attribute({class: wrapper_classes}) }}>
     {% if prefix %}
       <span class="field-prefix">{{ prefix }}</span>
     {% endif %}

--- a/tests/src/Functional/ThemeSettingsTest.php
+++ b/tests/src/Functional/ThemeSettingsTest.php
@@ -88,13 +88,16 @@ class ThemeSettingsTest extends BrowserTestBase {
     $bc_wrapper = $assert_session->elementExists('xpath', '//details[./summary[.="Backward compatibility"]]');
     $card_image_hidden_checkbox = $assert_session->fieldExists('Card image hidden on mobile', $bc_wrapper);
     $card_use_grid_checkbox = $assert_session->fieldExists('Card to use grid classes', $bc_wrapper);
+    $fieldset_wrapper_col_sm_10 = $assert_session->fieldExists('Fieldset wrapper uses col-sm-10', $bc_wrapper);
 
     // BC settings are disabled on new installs.
     $this->assertFalse($card_image_hidden_checkbox->isChecked());
     $this->assertFalse($card_use_grid_checkbox->isChecked());
+    $this->assertFalse($fieldset_wrapper_col_sm_10->isChecked());
 
     $this->assertFalse(BackwardCompatibility::getSetting('card_search_image_hide_on_mobile'));
     $this->assertFalse(BackwardCompatibility::getSetting('card_search_use_grid_classes'));
+    $this->assertFalse(BackwardCompatibility::getSetting('fieldset_wrapper_col_sm_10'));
 
     $card_image_hidden_checkbox->check();
     $assert_session->buttonExists('Save configuration')->press();
@@ -107,6 +110,7 @@ class ThemeSettingsTest extends BrowserTestBase {
     \Drupal::configFactory()->clearStaticCache();
     $this->assertTrue(BackwardCompatibility::getSetting('card_search_image_hide_on_mobile'));
     $this->assertFalse(BackwardCompatibility::getSetting('card_search_use_grid_classes'));
+    $this->assertFalse(BackwardCompatibility::getSetting('fieldset_wrapper_col_sm_10'));
 
     $card_use_grid_checkbox->check();
     $assert_session->buttonExists('Save configuration')->press();
@@ -114,11 +118,27 @@ class ThemeSettingsTest extends BrowserTestBase {
 
     $this->assertTrue($card_image_hidden_checkbox->isChecked());
     $this->assertTrue($card_use_grid_checkbox->isChecked());
+    $this->assertFalse($fieldset_wrapper_col_sm_10->isChecked());
 
     drupal_static_reset('theme_get_setting');
     \Drupal::configFactory()->clearStaticCache();
     $this->assertTrue(BackwardCompatibility::getSetting('card_search_image_hide_on_mobile'));
     $this->assertTrue(BackwardCompatibility::getSetting('card_search_use_grid_classes'));
+    $this->assertFalse(BackwardCompatibility::getSetting('fieldset_wrapper_col_sm_10'));
+
+    $fieldset_wrapper_col_sm_10->check();
+    $assert_session->buttonExists('Save configuration')->press();
+    $assert_session->pageTextContains('The configuration options have been saved.');
+
+    $this->assertTrue($card_image_hidden_checkbox->isChecked());
+    $this->assertTrue($card_use_grid_checkbox->isChecked());
+    $this->assertTrue($fieldset_wrapper_col_sm_10->isChecked());
+
+    drupal_static_reset('theme_get_setting');
+    \Drupal::configFactory()->clearStaticCache();
+    $this->assertTrue(BackwardCompatibility::getSetting('card_search_image_hide_on_mobile'));
+    $this->assertTrue(BackwardCompatibility::getSetting('card_search_use_grid_classes'));
+    $this->assertTrue(BackwardCompatibility::getSetting('fieldset_wrapper_col_sm_10'));
   }
 
   /**

--- a/tests/src/Kernel/MarkupRenderingTest.php
+++ b/tests/src/Kernel/MarkupRenderingTest.php
@@ -12,6 +12,7 @@ use Drupal\Core\Serialization\Yaml;
 use Drupal\Core\Site\Settings;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\oe_bootstrap_theme\Kernel\fixtures\PatternTestDataMassager;
+use Drupal\Tests\oe_bootstrap_theme\Traits\BackwardCompatibilityTrait;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
@@ -25,6 +26,8 @@ use Symfony\Component\DomCrawler\Crawler;
  * @group oe_bootstrap_theme
  */
 class MarkupRenderingTest extends KernelTestBase implements FormInterface {
+
+  use BackwardCompatibilityTrait;
 
   /**
    * {@inheritdoc}
@@ -111,10 +114,18 @@ class MarkupRenderingTest extends KernelTestBase implements FormInterface {
    *   A render array.
    * @param array $expectations
    *   Test assertion expectations.
+   * @param array $bc_settings
+   *   A list of backward compatibility settings and their values.
    *
    * @dataProvider markupRenderingProvider
    */
-  public function testMarkupRendering(array $render_array, array $expectations): void {
+  public function testMarkupRendering(array $render_array, array $expectations, array $bc_settings = []): void {
+    if (!empty($bc_settings)) {
+      foreach ($bc_settings as $name => $value) {
+        $this->setBackwardCompatibilitySetting($name, $value);
+      }
+    }
+
     // Wrap all the test structure inside a form. This will allow proper
     // processing of form elements and invocation of form alter hooks. Even if
     // the elements being tested are not form related, the form can host them

--- a/tests/src/Kernel/fixtures/markup_rendering.yml
+++ b/tests/src/Kernel/fixtures/markup_rendering.yml
@@ -137,6 +137,19 @@ fieldset:
     equals:
       'fieldset legend.col-form-label span.fieldset-legend': 'Fieldset title'
       'fieldset div.fieldset-wrapper': 'This is a child of the fieldset.'
+fieldset_bc_fieldset_wrapper_col_sm_10:
+  render:
+    '#type': fieldset
+    '#title': 'Fieldset title'
+    'child':
+      '#plain_text': 'This is a child of the fieldset.'
+  assert:
+    count:
+      'fieldset': 1
+      'fieldset div.fieldset-wrapper': 1
+      'fieldset div.fieldset-wrapper.col-sm-10': 1
+  backward_compatibility:
+    fieldset_wrapper_col_sm_10: true
 status_messages_error:
   render:
     '#theme': 'status_messages'

--- a/tests/src/Kernel/fixtures/markup_rendering.yml
+++ b/tests/src/Kernel/fixtures/markup_rendering.yml
@@ -121,6 +121,22 @@ submit_disabled:
       'input[type=submit].form-submit.button.btn': 1
       'input[value=Save]': 1
       'input.btn-primary': 1
+fieldset:
+  render:
+    '#type': fieldset
+    '#title': 'Fieldset title'
+    'child':
+      '#plain_text': 'This is a child of the fieldset.'
+  assert:
+    count:
+      'fieldset': 1
+      'fieldset.form-item.mb-3': 1
+      'fieldset div.fieldset-wrapper': 1
+      # BC compatibility setting should be disabled by default.
+      'fieldset div.fieldset-wrapper.col-sm-10': 0
+    equals:
+      'fieldset legend.col-form-label span.fieldset-legend': 'Fieldset title'
+      'fieldset div.fieldset-wrapper': 'This is a child of the fieldset.'
 status_messages_error:
   render:
     '#theme': 'status_messages'

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -65,4 +65,11 @@ function oe_bootstrap_theme_form_system_theme_settings_alter(&$form, FormStateIn
     '#description' => t('Card search variant used grid classes to structure its content left-right, this changed to col-12 and cl-card-start-col combination, this has an impact on the column sizes.'),
     '#default_value' => BackwardCompatibility::getSetting('card_search_use_grid_classes'),
   ];
+
+  $form['backward_compatibility']['fieldset_wrapper_col_sm_10'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Fieldset wrapper uses col-sm-10'),
+    '#description' => t('Fieldset wrapper had a class col-sm-10 which caused a different width for its content compared to the rest of the elements.'),
+    '#default_value' => BackwardCompatibility::getSetting('fieldset_wrapper_col_sm_10'),
+  ];
 }


### PR DESCRIPTION
The class is maintained for existing installations via a backward compatibility setting.
You can disable the setting at `/admin/appearance/settings/<your theme name>`.