### PR TITLE
OEL-2744: Responsive tables missing the toggle to show/hide "low priority column".

### DIFF
--- a/resources/sass/overrides/_table.scss
+++ b/resources/sass/overrides/_table.scss
@@ -7,3 +7,24 @@ a.tabledrag-handle {
     margin: -0.2em 0.5em 0;
   }
 }
+
+th.priority-low,
+th.priority-medium,
+td.priority-low,
+td.priority-medium {
+  display: none;
+}
+
+@media screen and (min-width: 768px) {
+  th.priority-medium,
+  td.priority-medium {
+    display: table-cell;
+  }
+}
+
+@media screen and (min-width: 992px) {
+  th.priority-low,
+  td.priority-low {
+    display: table-cell;
+  }
+}


### PR DESCRIPTION
Jira issue(s):
- [OEL-2744](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-2744)
