### PR TITLE
Issue-405: Do not preprocess navigation_menu.

### DIFF
--- a/src/MenuPreprocess.php
+++ b/src/MenuPreprocess.php
@@ -23,7 +23,7 @@ class MenuPreprocess {
    *   The preprocess hook.
    */
   public function preprocessMenu(array &$variables, string $hook): void {
-    if ($hook === 'menu__toolbar') {
+    if (in_array($hook, ['menu__toolbar', 'navigation_menu'])) {
       return;
     }
 


### PR DESCRIPTION
Jira issue(s):
- [D8TEFSA-1874](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/D8TEFSA-1874) : Upgrade to Drupal 10.3 and PHP 8.3

1. enable the new navigation menu
...

https://github.com/openeuropa/oe_bootstrap_theme/issues/405