### PR TITLE
OEL-3413: Removed default throbbler image of js form elements.

### DIFF
--- a/resources/sass/overrides/_all.scss
+++ b/resources/sass/overrides/_all.scss
@@ -3,6 +3,7 @@
 @import 'toolbar';
 @import 'table';
 @import 'inpage_navigation';
+@import 'js_throbbler';
 
 button.link {
   display: inline;

--- a/resources/sass/overrides/_js_throbbler.scss
+++ b/resources/sass/overrides/_js_throbbler.scss
@@ -1,0 +1,5 @@
+// Remove default js ajax form elements for accessibility contrast error.
+// -----------------------------------------------------------------------------
+.js input.form-autocomplete {
+  background-image: none;
+}


### PR DESCRIPTION
Jira issue(s):
- [D8AGE-???](https://webgate.ec.europa.eu/CITnet/jira/browse/D8AGE-???)
