### PR TITLE
OEL-3902: Remove visually hidden H2 from menu templates.

### DIFF
--- a/config/optional/block.block.oe_bootstrap_theme_mainnavigation.yml
+++ b/config/optional/block.block.oe_bootstrap_theme_mainnavigation.yml
@@ -15,7 +15,7 @@ provider: null
 plugin: 'system_menu_block:main'
 settings:
   id: 'system_menu_block:main'
-  label: 'Main navigation'
+  label: 'Main navigation menu'
   provider: system
   label_display: '0'
   level: 1

--- a/templates/overrides/menu/menu--main.html.twig
+++ b/templates/overrides/menu/menu--main.html.twig
@@ -3,8 +3,11 @@
  * Template for the main menu.
  */
 #}
-{{ pattern('navigation', {
-  'variant': 'navbar',
-  'items': items,
-  'attributes': attributes.addClass('me-auto'),
-}) }}
+
+{{
+    pattern('navigation', {
+      'variant': 'navbar',
+      'items': items,
+      'attributes': attributes,
+    })
+}}

--- a/templates/overrides/navigation/block--system-menu-block--main.html.twig
+++ b/templates/overrides/navigation/block--system-menu-block--main.html.twig
@@ -9,16 +9,20 @@
  * @see ./core/modules/system/templates/block--system-menu-block.html.twig
  */
 #}
-{% set heading_id = attributes.id ~ '-menu'|clean_id %}
-{# Label. If not displayed, we still provide it for screen readers. #}
-{% if not configuration.label_display %}
-  {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+
+{% if configuration.label_display %}
+  {% set heading_id = attributes.id ~ '-menu'|clean_id %}
+
+  {{ title_prefix }}
+  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  {{ title_suffix }}
+{% elseif not attributes.hasAttribute('aria-label') %}
+  {% set attributes = attributes.setAttribute('role', 'navigation').setAttribute('aria-label', configuration.label) %}
 {% endif %}
-{{ title_prefix }}
-<h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
-{{ title_suffix }}
 
 {# Menu. #}
 {% block content %}
-  {{ content }}
+ <div{{ attributes.addClass(['me-auto']) }}>
+    {{ content }}
+  </div>
 {% endblock %}

--- a/templates/overrides/navigation/block--system-menu-block.html.twig
+++ b/templates/overrides/navigation/block--system-menu-block.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a menu block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * https://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% set _heading_id = attributes.id ~ '-menu'|clean_id %}
+{% set _heading_tag = heading_tag|default('h2') %}
+
+{% if configuration.label_display %}
+  {% set attributes = attributes.setAttribute('aria-labelledby', _heading_id) %}
+{% elseif not attributes.hasAttribute('aria-label') %}
+  {% set attributes = attributes.setAttribute('aria-label', configuration.label) %}
+{% endif %}
+
+<nav{{ attributes }}>
+  {# Title (in case it is configured to be displayed). #}
+  {% if configuration.label_display %}
+    {{ title_prefix }}
+    <{{ _heading_tag }}{{ title_attributes.setAttribute('id', _heading_id) }}>{{ configuration.label }}</{{ _heading_tag }}>
+    {{ title_suffix }}
+  {% endif %}
+
+  {# Menu. #}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</nav>


### PR DESCRIPTION
Jira issue(s):

[OEL-3902](https://webgate.ec.europa.eu/CITnet/jira/browse/OEL-3902)

Fixed:

* Remove visually hidden H2 from menu templates.
* Adjust default aria-label attribute for main menu.