### PR TITLE
OEL-3845: Fix error when preprocessing new navigation menu introduced in core 10.3+.

### DIFF
--- a/src/MenuPreprocess.php
+++ b/src/MenuPreprocess.php
@@ -23,7 +23,7 @@ class MenuPreprocess {
    *   The preprocess hook.
    */
   public function preprocessMenu(array &$variables, string $hook): void {
-    if ($hook === 'menu__toolbar') {
+    if (in_array($hook, ['menu__toolbar', 'navigation_menu'])) {
       return;
     }
 


### PR DESCRIPTION
Jira issue(s):

[OEL-3845](https://webgate.ec.europa.eu/CITnet/jira/browse/OEL-3845)

Fixed:

- Fix error when preprocessing new navigation menu introduced in core 10.3+.