### PR TITLE
OEL-4178: Test with drupal/core:~11.2.0.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -112,3 +112,5 @@ matrix:
       PHP_VERSION: 8.3
     - CORE_VERSION: 11.1.0
       PHP_VERSION: 8.3
+    - CORE_VERSION: 11.2.0
+      PHP_VERSION: 8.3

--- a/tests/src/Functional/ThemeSettingsTest.php
+++ b/tests/src/Functional/ThemeSettingsTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_bootstrap_theme\Functional;
 
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\oe_bootstrap_theme\Traits\GetSelectOptionsTrait;
 use Drupal\oe_bootstrap_theme\BackwardCompatibility;
 
 /**
  * Tests the theme settings.
  */
 class ThemeSettingsTest extends BrowserTestBase {
+
+  use GetSelectOptionsTrait;
 
   /**
    * {@inheritdoc}
@@ -47,7 +50,7 @@ class ThemeSettingsTest extends BrowserTestBase {
       'lg' => 'Large',
       'xl' => 'Extra large',
       'xxl' => 'Extra extra large',
-    ], $this->getOptions($responsive_field));
+    ], $this->getSelectOptions($responsive_field));
     $this->assertEquals('always', $responsive_field->getValue());
     // The MarkupRenderingTest runs assertions on the default config values
     // already.

--- a/tests/src/Traits/GetSelectOptionsTrait.php
+++ b/tests/src/Traits/GetSelectOptionsTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\oe_bootstrap_theme\Traits;
+
+use Behat\Mink\Element\Element;
+use Behat\Mink\Element\NodeElement;
+
+/**
+ * Contains a method to get select options.
+ */
+trait GetSelectOptionsTrait {
+
+  /**
+   * Helper function to get the options of select field.
+   *
+   * This replaces the core method which is now deprecated.
+   *
+   * @param \Behat\Mink\Element\NodeElement|string $select
+   *   Name, ID, or Label of select field to assert.
+   * @param \Behat\Mink\Element\Element|null $container
+   *   (optional) Container element to check against. Defaults to current page.
+   *
+   * @return array<string, string>
+   *   Associative array of option keys and values.
+   */
+  protected function getSelectOptions(string|NodeElement $select, ?Element $container = NULL): array {
+    if (is_string($select)) {
+      $select = $this->assertSession()->selectExists($select, $container);
+    }
+    $options = [];
+    /** @var \Behat\Mink\Element\NodeElement $option */
+    foreach ($select->findAll('xpath', '//option') as $option) {
+      $label = $option->getText();
+      $value = $option->getAttribute('value') ?: $label;
+      $options[$value] = $label;
+    }
+    return $options;
+  }
+
+}


### PR DESCRIPTION
### Known issue

We have one deprecation notice in phpunit, in TwigExtensionTest::testElementChildrenFilter, for calling ->render($build, TRUE). It occurs if we run phpunit with `--fail-on-notice`.

> 1) /var/www/html/build/core/lib/Drupal/Core/Render/Renderer.php:223
> Drupal\Core\Render\Renderer::render with $is_root_call is deprecated in drupal:11.2.0 and is removed from drupal:12.0.0. Use Drupal\Core\Render\Renderer::renderRoot() instead.  See https://www.drupal.org/
> node/3497318.
> 
> Triggered by:
> 
> * Drupal\Tests\oe_bootstrap_theme_helper\Kernel\TwigExtensionTest::testElementChildrenFilter (8 times)
>  /var/www/html/modules/oe_bootstrap_theme_helper/tests/src/Kernel/TwigExtensionTest.php:242
> 

Here is the code snippet:

```php
        $render_context = new RenderContext();
        $output = $renderer->executeInRenderContext($render_context, function () use ($renderer, $build) {
          return $renderer->render($build, TRUE);
        });

        $bubbled_metadata = [];
        $render_context->pop()->applyTo($bubbled_metadata);
```
As we can see, we need the `$render_context` afterwards.

I did not find a suitable replacement for this code.
Simply replacing `->render(*, TRUE)` with `->renderRoot(*)` results in test failure.
When replacing the entire `->executeInRenderContext()` call, we don't have access to the `$render_context` anymore.

Besides, we still want this to work in 10.x.

This is only called in a test, and I don't think it is a problem.