### PR TITLE
OEL-4559: Header search button must have accessible / discernible text

### DIFF
--- a/templates/patterns/button/pattern-button.html.twig
+++ b/templates/patterns/button/pattern-button.html.twig
@@ -7,6 +7,13 @@
 {% if icon %}
   {% set icon_data = icon is iterable ? icon : { name: icon } %}
   {% set _icon = { path: bcl_icon_path }|merge(icon_data) %}
+  {% if label is empty and _icon.attributes['aria-label'] is not empty %}
+    {% set _icon = _icon|merge({
+      attributes: _icon.attributes
+        .setAttribute('aria-hidden', 'true')
+        .setAttribute('focusable', 'false')
+    }) %}
+  {% endif %}
 {% endif %}
 {% include '@oe-bcl/button' with {
   'label': label,


### PR DESCRIPTION
accessibility, set aria-hidden and focusable=false on icon
Apply attributes when an icon is defined, no visible label is present,
and an aria-label is provided.